### PR TITLE
feat: add inputs for specifiable config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,10 @@ jobs:
       - name: Check formatting specific config
         uses: ./
         with:
-          dprint-config-path: 'dprint-another.json'
+          config-path: 'dprint-another.json'
 
-      - name: Check formatting old version and specific config
+      - name: Check formatting specific version and config
         uses: ./
         with:
-          # config schema `projectType` is removed since 0.15.0
-          # ref: https://github.com/dprint/dprint/commit/f41d1fa50d68fd0d0c1a7def9fb6cbae25b0ddc6
-          dprint-version: 0.15.0
-          dprint-config-path: 'dprint-another.json'
+          dprint-version: 0.30.3
+          config-path: 'dprint-another.json'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,16 @@ jobs:
         uses: ./
         with:
           dprint-version: 0.30.3
+
+      - name: Check formatting specific config
+        uses: ./
+        with:
+          dprint-config-path: 'dprint-another.json'
+
+      - name: Check formatting old version and specific config
+        uses: ./
+        with:
+          # config schema `projectType` is removed since 0.15.0
+          # ref: https://github.com/dprint/dprint/commit/f41d1fa50d68fd0d0c1a7def9fb6cbae25b0ddc6
+          dprint-version: 0.15.0
+          dprint-config-path: 'dprint-another.json'

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ By default, `dprint/check` uses the `dprint.json`.
 
 ### Specific Config
 
-To use a specific config, specify that with the `dprint-config-path` input:
+To use a specific config, specify that with the `config-path` input:
 
 ```yml
 - uses: dprint/check@v2.1
   with:
-    dprint-config-path: dprint-ci.json
+    config-path: dprint-ci.json
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ To use a specific version, specify that with the `dprint-version` input:
     dprint-version: 0.30.3
 ```
 
+### Config Path
+
+By default, `dprint/check` uses the `dprint.json`.
+
+### Specific Config
+
+To use a specific config, specify that with the `dprint-config-path` input:
+
+```yml
+- uses: dprint/check@v2.1
+  with:
+    dprint-config-path: dprint-ci.json
+```
+
 ## Troubleshooting
 
 ### Windows line endings

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Specific dprint version to use (ex. 0.30.3)'
     required: false
     default: ''
+  dprint-config-path:
+    description: 'Specific dprint config to use (ex. dprint.json)'
+    required: true
+    default: 'dprint.json'
 runs:
   using: 'composite'
   steps:
@@ -16,7 +20,7 @@ runs:
         echo "/home/runner/.dprint/bin" >> $GITHUB_PATH
     - name: Check formatting
       shell: bash
-      run: ~/.dprint/bin/dprint check
+      run: ~/.dprint/bin/dprint check --config '${{ inputs.dprint-config-path }}'
 branding:
   icon: 'check-circle'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,10 @@ inputs:
     description: 'Specific dprint version to use (ex. 0.30.3)'
     required: false
     default: ''
-  dprint-config-path:
+  config-path:
     description: 'Specific dprint config to use (ex. dprint.json)'
-    required: true
-    default: 'dprint.json'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -20,7 +20,11 @@ runs:
         echo "/home/runner/.dprint/bin" >> $GITHUB_PATH
     - name: Check formatting
       shell: bash
-      run: ~/.dprint/bin/dprint check --config '${{ inputs.dprint-config-path }}'
+      if: "${{ inputs.config-path == '' }}"
+      run: ~/.dprint/bin/dprint check
+    - name: Check formatting with config
+      if: "${{ inputs.config-path != '' }}"
+      run: ~/.dprint/bin/dprint check --config '${{ inputs.config-path }}'
 branding:
   icon: 'check-circle'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,7 @@ runs:
       if: "${{ inputs.config-path == '' }}"
       run: ~/.dprint/bin/dprint check
     - name: Check formatting with config
+      shell: bash
       if: "${{ inputs.config-path != '' }}"
       run: ~/.dprint/bin/dprint check --config '${{ inputs.config-path }}'
 branding:

--- a/dprint-another.json
+++ b/dprint-another.json
@@ -1,0 +1,7 @@
+{
+  "includes": ["**/*.{md,json}"],
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.15.3.wasm",
+    "https://plugins.dprint.dev/markdown-0.13.3.wasm"
+  ]
+}


### PR DESCRIPTION
## Motivation

I would like to have another config between editor integration and CI.

Because I'm using https://github.com/dprint/dprint-plugin-exec to hook other formatters in vscode.  
However, as far I I know https://github.com/dprint/dprint-vscode cannot specify another config in the same directory structure.  
So...
  - I use `dprint.json` in vscode for now.
  - I would like to use a different config than `dprint.json` in `dprint/check`. # This PR
  - Dare I say, I would specify another config as `dprint-editor.json` in the vscode integration.

## I didn't have confidence for...

Added an old version test to the CI to make sure this change does not break current usage. 
But 0.14.0 or earlier didn't work with the current [dprint.json](https://github.com/dprint/check/blob/c0ea92f1856416018ac82b516dbb361da88816bf/dprint.json), even without adding this change.