### PR TITLE
feat: add `args` input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           dprint-version: 0.30.3
           config-path: 'dprint.json'
+
       - name: make poorly-formatted json file
         run: |
           echo '{"a": 1, "b": 2}' > poorly-formatted.json
@@ -41,6 +42,4 @@ jobs:
         uses: ./
         with:
           args: --excludes poorly-formatted.json
-
-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,13 @@ jobs:
         with:
           dprint-version: 0.30.3
           config-path: 'dprint.json'
+      - name: make poorly-formatted json file
+        run: |
+          echo '{"a": 1, "b": 2}' > poorly-formatted.json
+      - name: Check formatting with excludes
+        uses: ./
+        with:
+          args: --excludes poorly-formatted.json
+
+
+

--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ To use a specific config, specify that with the `config-path` input:
     config-path: dprint-ci.json
 ```
 
+### Args
+
+To pass additional arguments to `dprint check`, pass them to the `args` input. E.g. to only check changed files:
+
+```yml
+- name: Get changed files
+  id: changed-files
+  uses: tj-actions/changed-files@v45
+- uses: dprint/check@v2.2
+  with:
+    args: >-
+      --allow-no-files
+      ${{ steps.changed-files.outputs.all_changed_files }}
+```
+
 ## Troubleshooting
 
 ### Windows line endings

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Specific dprint config to use (ex. dprint.json)'
     required: false
     default: ''
+  args:
+    description: 'Additional arguments to pass to dprint check'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -21,11 +25,11 @@ runs:
     - name: Check formatting
       shell: bash
       if: "${{ inputs.config-path == '' }}"
-      run: ~/.dprint/bin/dprint check
+      run: ~/.dprint/bin/dprint check ${{ inputs.args }}
     - name: Check formatting with config
       shell: bash
       if: "${{ inputs.config-path != '' }}"
-      run: ~/.dprint/bin/dprint check --config '${{ inputs.config-path }}'
+      run: ~/.dprint/bin/dprint check --config '${{ inputs.config-path }}' ${{ inputs.args }}
 branding:
   icon: 'check-circle'
   color: 'gray-dark'


### PR DESCRIPTION
Adds `args` input to allow for passing arbitrary additional arguments to `dprint check`

**Alternatives considered**

Add specific inputs for the things that I need:

- `files`
- `--excludes`
- `--allow-no-files`